### PR TITLE
add arithmatex

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,12 @@ edit_uri: edit/main/docs/
 repo_url: https://github.com/Miuarcher/miumiu.github.io
 repo_name: miumiu.github.io
 
+markdown_extensions:
+  # [数学公式支持]
+  # https://squidfunk.github.io/mkdocs-material/reference/math/#katex
+  - pymdownx.arithmatex:
+      generic: true
+
 extra_javascript:
   # [数学公式支持]
   # https://squidfunk.github.io/mkdocs-material/reference/math/#katex


### PR DESCRIPTION
添加arithmatex，这样美元符号中的反斜杠就不会被解析为普通的转义字符。
但是，块公式中的换行会导致网页中多余的换行。